### PR TITLE
[Feat/#85] 콘서트 정보 탭 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tanstack/react-query": "^5.75.2",
         "@types/react-slick": "^0.23.13",
         "axios": "^1.9.0",
+        "dayjs": "^1.11.13",
         "embla-carousel-react": "^8.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4333,6 +4334,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query": "^5.75.2",
     "@types/react-slick": "^0.23.13",
     "axios": "^1.9.0",
+    "dayjs": "^1.11.13",
     "embla-carousel-react": "^8.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import SearchPage from "../pages/SearchPage";
 import LyricPage from "../pages/LyricPage";
 import SetlistCollectionPage from "../pages/SetlistCollectionPage";
 import SetlistDetailPage from "../pages/SetlistDetailPage";
+import MdPage from "../pages/MdPage";
 
 const queryClient = new QueryClient();
 
@@ -54,6 +55,10 @@ const router = createBrowserRouter([
       {
         path: "setlist/:setlistId/:concertId",
         element: <SetlistDetailPage />,
+      },
+      {
+        path: "md",
+        element: <MdPage />,
       },
     ],
   },

--- a/src/entities/concert/api/getConcertRequiredInfo.ts
+++ b/src/entities/concert/api/getConcertRequiredInfo.ts
@@ -1,0 +1,18 @@
+import { ApiResponse } from "../../../shared/types/response";
+import axiosInstance from "../../../shared/api/axiosInstance";
+
+export type ConcertRequired = {
+  id: number;
+  category: string;
+  content: string;
+  imgUrl: string;
+};
+
+export async function getConcertRequiredInfo(
+  id: number
+): Promise<ConcertRequired[]> {
+  const response = await axiosInstance.get<ApiResponse<ConcertRequired[]>>(
+    `/api/v2/concerts/${id}/info`
+  );
+  return response.data.data;
+}

--- a/src/entities/concert/api/getMd.ts
+++ b/src/entities/concert/api/getMd.ts
@@ -1,0 +1,16 @@
+import { ApiResponse } from "../../../shared/types/response";
+import axiosInstance from "../../../shared/api/axiosInstance";
+
+export type Md = {
+  id: number;
+  name: string;
+  price: string;
+  imgUrl: string;
+};
+
+export async function getMd(id: number): Promise<Md[]> {
+  const response = await axiosInstance.get<ApiResponse<Md[]>>(
+    `/api/v2/concerts/${id}/mds`
+  );
+  return response.data.data;
+}

--- a/src/entities/concert/api/getSchedule.ts
+++ b/src/entities/concert/api/getSchedule.ts
@@ -1,0 +1,15 @@
+import { ApiResponse } from "../../../shared/types/response";
+import axiosInstance from "../../../shared/api/axiosInstance";
+
+export type Schedule = {
+  id: number;
+  category: string;
+  scheduledAt: string;
+};
+
+export async function getSchedule(id: number): Promise<Schedule[]> {
+  const response = await axiosInstance.get<ApiResponse<Schedule[]>>(
+    `/api/v2/concerts/${id}/schedule`
+  );
+  return response.data.data;
+}

--- a/src/entities/concert/ui/ArtistInfo.tsx
+++ b/src/entities/concert/ui/ArtistInfo.tsx
@@ -1,0 +1,107 @@
+import InstagramIcon from "../../../shared/assets/InstagramIcon.svg";
+import { formatBirthDate } from "../utils/formatBirthDate";
+
+interface ArtistInfoProps {
+  concertId: number;
+  artist: string;
+  birthDate: string;
+  birthPlace: string;
+  category: string;
+  detail: string;
+  instagramUrl: string;
+  keywords: string[];
+  imgUrl: string;
+}
+
+function ArtistInfo({
+  artist,
+  birthDate,
+  birthPlace,
+  category,
+  detail,
+  instagramUrl,
+  keywords,
+  imgUrl,
+}: ArtistInfoProps) {
+  return (
+    <>
+      <div className="mx-16">
+        <div className="pt-24 pb-17">
+          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+            가수에 대한
+            <br />
+            정보를 필독해요
+          </p>
+        </div>
+
+        <div>
+          <div className="bg-grayScaleBlack90 rounded-8 border border-grayScaleBlack80">
+            <div className="relative w-full h-142 ">
+              <img
+                src={imgUrl}
+                className="w-full h-full object-cover rounded-t-8"
+              ></img>
+            </div>
+
+            <div className="pt-16 pr-16 pl-16 pb-24 ">
+              <div className="relative">
+                <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-24">
+                  <p className="px-13 py-4 text-grayScaleBlack100 text-caption-smd font-semibold font-NotoSansKR">
+                    {category}
+                  </p>
+                </div>
+                <p className="pt-8 text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
+                  {artist}
+                </p>
+                {instagramUrl && (
+                  <a
+                    href={instagramUrl}
+                    target="_blank"
+                    className="absolute right-0 bottom-0 border-none cursor-pointer"
+                  >
+                    <img
+                      src={InstagramIcon}
+                      alt="instagram"
+                      className="w-30 h-30"
+                    />
+                  </a>
+                )}
+              </div>
+
+              <div className="pt-12 w-full border-b border-dashed border-grayScaleBlack50" />
+
+              <div>
+                <p className="pt-12 text-grayScaleWhite text-caption-lg font-semibold font-NotoSansKR">
+                  {detail}
+                </p>
+                <div className="flex pt-20">
+                  <p className="text-grayScaleWhite text-caption-lg font-semibold font-NotoSansKR">
+                    출생
+                  </p>
+                  <p className="pl-16 text-grayScaleBlack30 text-caption-sm font-regular font-NotoSansKR">
+                    {formatBirthDate(birthDate)}, {birthPlace}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-13">
+          {keywords.map((keyword, index) => (
+            <div
+              key={index}
+              className="mr-4 mb-6 inline-flex items-center justify-center bg-grayScaleBlack80 rounded-24"
+            >
+              <p className="px-13 py-4 text-grayScaleBlack30 text-caption-lg font-semibold font-NotoSansKR">
+                {keyword}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default ArtistInfo;

--- a/src/entities/concert/ui/ArtistTabPanel.tsx
+++ b/src/entities/concert/ui/ArtistTabPanel.tsx
@@ -1,3 +1,4 @@
+import { ConcertCulture } from "../api/getConcertCulture";
 import ArtistInfo from "./ArtistInfo";
 import FanCultureInfo from "./FanCultureInfo";
 
@@ -11,6 +12,7 @@ interface ArtistTabPanelProps {
   instagramUrl: string;
   keywords: string[];
   imgUrl: string;
+  concertCulture: ConcertCulture[];
 }
 
 function ArtistTabPanel({
@@ -23,21 +25,29 @@ function ArtistTabPanel({
   instagramUrl,
   keywords,
   imgUrl,
+  concertCulture,
 }: ArtistTabPanelProps) {
   return (
     <>
-      <ArtistInfo
-        concertId={concertId}
-        artist={artist}
-        birthDate={birthDate}
-        birthPlace={birthPlace}
-        category={category}
-        detail={detail}
-        instagramUrl={instagramUrl}
-        keywords={keywords}
-        imgUrl={imgUrl}
-      />
-      <FanCultureInfo concertId={concertId} />
+      {artist && (
+        <ArtistInfo
+          concertId={concertId}
+          artist={artist}
+          birthDate={birthDate}
+          birthPlace={birthPlace}
+          category={category}
+          detail={detail}
+          instagramUrl={instagramUrl}
+          keywords={keywords}
+          imgUrl={imgUrl}
+        />
+      )}
+      {concertCulture.length > 0 && (
+        <FanCultureInfo
+          concertCulture={concertCulture}
+          cultureCount={concertCulture.length}
+        />
+      )}
     </>
   );
 }

--- a/src/entities/concert/ui/ArtistTabPanel.tsx
+++ b/src/entities/concert/ui/ArtistTabPanel.tsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
-import InstagramIcon from "../../../shared/assets/InstagramIcon.svg";
-import FanCultureSwiper from "./FanCultureSwiper";
-import { formatBirthDate } from "../utils/formatBirthDate";
+import ArtistInfo from "./ArtistInfo";
+import FanCultureInfo from "./FanCultureInfo";
 
-interface ArtistInfoProps {
+interface ArtistTabPanelProps {
   concertId: number;
   artist: string;
   birthDate: string;
@@ -25,106 +23,21 @@ function ArtistTabPanel({
   instagramUrl,
   keywords,
   imgUrl,
-}: ArtistInfoProps) {
-  const [cultureCount, setCultureCount] = useState(0);
-
+}: ArtistTabPanelProps) {
   return (
     <>
-      <div className="mx-16">
-        <div className="pt-24 pb-17">
-          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
-            가수에 대한
-            <br />
-            정보를 필독해요
-          </p>
-        </div>
-
-        <div>
-          <div className="bg-grayScaleBlack90 rounded-8 border border-grayScaleBlack80">
-            <div className="relative w-full h-142 ">
-              <img
-                src={imgUrl}
-                className="w-full h-full object-cover rounded-t-8"
-              ></img>
-            </div>
-
-            <div className="pt-16 pr-16 pl-16 pb-24 ">
-              <div className="relative">
-                <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-24">
-                  <p className="px-13 py-4 text-grayScaleBlack100 text-caption-smd font-semibold font-NotoSansKR">
-                    {category}
-                  </p>
-                </div>
-                <p className="pt-8 text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
-                  {artist}
-                </p>
-                {instagramUrl && (
-                  <a
-                    href={instagramUrl}
-                    target="_blank"
-                    className="absolute right-0 bottom-0 border-none cursor-pointer"
-                  >
-                    <img
-                      src={InstagramIcon}
-                      alt="instagram"
-                      className="w-30 h-30"
-                    />
-                  </a>
-                )}
-              </div>
-
-              <div className="pt-12 w-full border-b border-dashed border-grayScaleBlack50" />
-
-              <div>
-                <p className="pt-12 text-grayScaleWhite text-caption-lg font-semibold font-NotoSansKR">
-                  {detail}
-                </p>
-                <div className="flex pt-20">
-                  <p className="text-grayScaleWhite text-caption-lg font-semibold font-NotoSansKR">
-                    출생
-                  </p>
-                  <p className="pl-16 text-grayScaleBlack30 text-caption-sm font-regular font-NotoSansKR">
-                    {formatBirthDate(birthDate)}, {birthPlace}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-13">
-          {keywords.map((keyword, index) => (
-            <div
-              key={index}
-              className="mr-4 mb-6 inline-flex items-center justify-center bg-grayScaleBlack80 rounded-24"
-            >
-              <p className="px-13 py-4 text-grayScaleBlack30 text-caption-lg font-semibold font-NotoSansKR">
-                {keyword}
-              </p>
-            </div>
-          ))}
-        </div>
-
-        <div className="pt-24 pb-20">
-          <div className="flex">
-            <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-4">
-              <p className="px-7 text-grayScaleBlack100 text-body-lg font-semibold font-NotoSansKR">
-                {cultureCount}개
-              </p>
-            </div>
-            <p className="ml-4 text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
-              의 팬문화와
-            </p>
-          </div>
-          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
-            꿀팁을 한 눈에 알아봐요
-          </p>
-        </div>
-      </div>
-      <FanCultureSwiper
+      <ArtistInfo
         concertId={concertId}
-        onCultureCountChange={setCultureCount}
+        artist={artist}
+        birthDate={birthDate}
+        birthPlace={birthPlace}
+        category={category}
+        detail={detail}
+        instagramUrl={instagramUrl}
+        keywords={keywords}
+        imgUrl={imgUrl}
       />
+      <FanCultureInfo concertId={concertId} />
     </>
   );
 }

--- a/src/entities/concert/ui/ConcertInfoTab.tsx
+++ b/src/entities/concert/ui/ConcertInfoTab.tsx
@@ -115,7 +115,7 @@ function ConcertInfoTab({ concertId }: Props) {
           )}
         </TabPanel>
         <TabPanel value="concert" className="p-0">
-          <ConcertTabPanel />
+          <ConcertTabPanel concertId={concertId} />
           {/* <EmptyConcertInfoTabPanel text={"콘서트 정보"} /> */}
         </TabPanel>
         <TabPanel value="setlist">셋리스트 내용</TabPanel>

--- a/src/entities/concert/ui/ConcertInfoTab.tsx
+++ b/src/entities/concert/ui/ConcertInfoTab.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { getArtistInfo, Artist } from "../api/getArtistInfo";
 import { getConcertCulture, ConcertCulture } from "../api/getConcertCulture";
+import { getSchedule, Schedule } from "../api/getSchedule";
+import {
+  getConcertRequiredInfo,
+  ConcertRequired,
+} from "../api/getConcertRequiredInfo";
+import { getMd, Md } from "../api/getMd";
 import ArtistTabPanel from "./ArtistTabPanel";
 import ConcertTabPanel from "./ConcertTabPanel";
 import EmptyConcertInfoTabPanel from "./EmptyConcertInfoTabPanel";
@@ -19,8 +25,14 @@ interface ConcertInfoTabProps {
 
 function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
   const [selectedTab, setSelectedTab] = useState("artist");
+
   const [artist, setArtist] = useState<Artist | null>(null);
   const [ConcertCulture, setConcertCulture] = useState<ConcertCulture[]>([]);
+  const [schedules, setSchedule] = useState<Schedule[] | null>(null);
+  const [concertRequiredInfo, setConcertRequiredInfo] = useState<
+    ConcertRequired[] | null
+  >(null);
+  const [mds, setMd] = useState<Md[] | null>(null);
 
   useEffect(() => {
     if (!concertId || isNaN(concertId)) {
@@ -49,6 +61,48 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
     };
 
     fetchConcertCulture();
+  }, [concertId]);
+
+  useEffect(() => {
+    const fetchSchedule = async () => {
+      try {
+        const data = await getSchedule(concertId);
+        setSchedule(data);
+      } catch (error) {
+        console.error("특정 콘서트 일정 목록 조회 API 호출 실패:", error);
+        setSchedule([]);
+      }
+    };
+
+    fetchSchedule();
+  }, [concertId]);
+
+  useEffect(() => {
+    const fetchConcertRequiredInfo = async () => {
+      try {
+        const data = await getConcertRequiredInfo(concertId);
+        setConcertRequiredInfo(data);
+      } catch (error) {
+        console.error("특정 콘서트 필수 정보 목록 조회 API 호출 실패:", error);
+        setConcertRequiredInfo([]);
+      }
+    };
+
+    fetchConcertRequiredInfo();
+  }, [concertId]);
+
+  useEffect(() => {
+    const fetchMds = async () => {
+      try {
+        const data = await getMd(concertId);
+        setMd(data);
+      } catch (error) {
+        console.error("특정 콘서트의 MD 목록 조회 API 호출 실패:", error);
+        setMd([]);
+      }
+    };
+
+    fetchMds();
   }, [concertId]);
 
   return (
@@ -132,8 +186,19 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
           )}
         </TabPanel>
         <TabPanel value="concert" className="p-0">
-          <ConcertTabPanel concertId={concertId} ticketUrl={ticketUrl} />
-          {/* <EmptyConcertInfoTabPanel text={"콘서트 정보"} /> */}
+          {(!schedules || schedules.length === 0) &&
+          (!concertRequiredInfo || concertRequiredInfo.length === 0) &&
+          (!mds || mds.length === 0) ? (
+            <EmptyConcertInfoTabPanel text={"콘서트 정보"} />
+          ) : (
+            <ConcertTabPanel
+              concertId={concertId}
+              ticketUrl={ticketUrl}
+              schedules={schedules}
+              concertRequiredInfo={concertRequiredInfo}
+              mds={mds}
+            />
+          )}
         </TabPanel>
         <TabPanel value="setlist">셋리스트 내용</TabPanel>
       </TabsBody>

--- a/src/entities/concert/ui/ConcertInfoTab.tsx
+++ b/src/entities/concert/ui/ConcertInfoTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getArtistInfo, Artist } from "../api/getArtistInfo";
+import { getConcertCulture, ConcertCulture } from "../api/getConcertCulture";
 import ArtistTabPanel from "./ArtistTabPanel";
 import ConcertTabPanel from "./ConcertTabPanel";
 import EmptyConcertInfoTabPanel from "./EmptyConcertInfoTabPanel";
@@ -19,6 +20,7 @@ interface ConcertInfoTabProps {
 function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
   const [selectedTab, setSelectedTab] = useState("artist");
   const [artist, setArtist] = useState<Artist | null>(null);
+  const [ConcertCulture, setConcertCulture] = useState<ConcertCulture[]>([]);
 
   useEffect(() => {
     if (!concertId || isNaN(concertId)) {
@@ -34,6 +36,19 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
       }
     }
     fetchConcert();
+  }, [concertId]);
+
+  useEffect(() => {
+    const fetchConcertCulture = async () => {
+      try {
+        const data = await getConcertCulture(concertId);
+        setConcertCulture(data);
+      } catch (error) {
+        console.error("특정 콘서트 공연 문화 목록 조회 API 호출 실패:", error);
+      }
+    };
+
+    fetchConcertCulture();
   }, [concertId]);
 
   return (
@@ -99,20 +114,21 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
 
       <TabsBody {...({} as any)}>
         <TabPanel value="artist" className="p-0">
-          {artist ? (
+          {!artist && ConcertCulture.length === 0 ? (
+            <EmptyConcertInfoTabPanel text={"가수 정보"} />
+          ) : (
             <ArtistTabPanel
               concertId={concertId}
-              artist={artist.artist}
-              birthDate={artist.birthDate}
-              birthPlace={artist.birthPlace}
-              category={artist.category}
-              detail={artist.detail}
-              instagramUrl={artist.instagramUrl}
-              keywords={artist.keywords}
-              imgUrl={artist.imgUrl}
+              artist={artist?.artist || ""}
+              birthDate={artist?.birthDate || ""}
+              birthPlace={artist?.birthPlace || ""}
+              category={artist?.category || ""}
+              detail={artist?.detail || ""}
+              instagramUrl={artist?.instagramUrl || ""}
+              keywords={artist?.keywords || []}
+              imgUrl={artist?.imgUrl || ""}
+              concertCulture={ConcertCulture}
             />
-          ) : (
-            <EmptyConcertInfoTabPanel text={"가수 정보"} />
           )}
         </TabPanel>
         <TabPanel value="concert" className="p-0">

--- a/src/entities/concert/ui/ConcertInfoTab.tsx
+++ b/src/entities/concert/ui/ConcertInfoTab.tsx
@@ -11,11 +11,12 @@ import {
   TabPanel,
 } from "@material-tailwind/react";
 
-interface Props {
+interface ConcertInfoTabProps {
   concertId: number;
+  ticketUrl: string;
 }
 
-function ConcertInfoTab({ concertId }: Props) {
+function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
   const [selectedTab, setSelectedTab] = useState("artist");
   const [artist, setArtist] = useState<Artist | null>(null);
 
@@ -115,7 +116,7 @@ function ConcertInfoTab({ concertId }: Props) {
           )}
         </TabPanel>
         <TabPanel value="concert" className="p-0">
-          <ConcertTabPanel concertId={concertId} />
+          <ConcertTabPanel concertId={concertId} ticketUrl={ticketUrl} />
           {/* <EmptyConcertInfoTabPanel text={"콘서트 정보"} /> */}
         </TabPanel>
         <TabPanel value="setlist">셋리스트 내용</TabPanel>

--- a/src/entities/concert/ui/ConcertInsideInfo.tsx
+++ b/src/entities/concert/ui/ConcertInsideInfo.tsx
@@ -1,31 +1,12 @@
-import { useEffect, useState } from "react";
-import { getConcertInsideInfo } from "../api/getConcertInsideInfo";
 import { Concert } from "../types";
 import DetailInfo from "../../../shared/ui/DetailInfo";
 import { formatConcertDate } from "../../../shared/utils/formatConcertDate";
 
-interface Props {
-  concertId: number;
+interface ConcertInsideInfoProps {
+  concert: Concert;
 }
 
-function ConcertInsideInfo({ concertId }: Props) {
-  const [concert, setConcert] = useState<Concert | null>(null);
-
-  useEffect(() => {
-    async function fetchConcert() {
-      try {
-        const data = await getConcertInsideInfo(concertId);
-        setConcert(data);
-      } catch (error) {
-        console.error("특정 콘서트 상세 정보 조회 API 호출 실패", error);
-      }
-    }
-
-    fetchConcert();
-  }, [concertId]);
-
-  if (!concert) return null;
-
+function ConcertInsideInfo({ concert }: ConcertInsideInfoProps) {
   return (
     <DetailInfo
       imageUrl={concert.poster}

--- a/src/entities/concert/ui/ConcertTabPanel.tsx
+++ b/src/entities/concert/ui/ConcertTabPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 // import ConcertSchedulePanel from "../../../features/concert/ui/ConcertSchedulePanel";
 import ConcertInfoCarousel from "../../../widgets/ConcertInfoCarousel";
 import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
@@ -12,6 +13,7 @@ interface MdProps {
 function ConcertTabPanel({ concertId }: MdProps) {
   const [mds, setMd] = useState<Md[] | null>(null);
   const [mdCount, setMdCount] = useState(0);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchMds = async () => {
@@ -62,7 +64,10 @@ function ConcertTabPanel({ concertId }: MdProps) {
           <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
             한 눈에 확인하세요
           </p>
-          <button className="absolute bottom-20 right-16 w-24 h-24 bg-transparent border-none p-0 cursor-pointer">
+          <button
+            className="absolute bottom-20 right-16 w-24 h-24 bg-transparent border-none p-0 cursor-pointer"
+            onClick={() => navigate("/md", { state: { concertId } })}
+          >
             <img src={ConcertRightArrow} className="w-full h-full" />
           </button>
         </div>

--- a/src/entities/concert/ui/ConcertTabPanel.tsx
+++ b/src/entities/concert/ui/ConcertTabPanel.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-// import ConcertSchedulePanel from "../../../features/concert/ui/ConcertSchedulePanel";
+import ConcertSchedulePanel from "../../../features/concert/ui/ConcertSchedulePanel";
 import ConcertInfoCarousel from "../../../widgets/ConcertInfoCarousel";
-import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
 import MdSlide from "../../../entities/concert/ui/MdSlide";
-import { getMd, Md } from "../api/getMd";
+import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
+import { getSchedule, Schedule } from "../api/getSchedule";
 import {
   getConcertRequiredInfo,
   ConcertRequired,
 } from "../api/getConcertRequiredInfo";
+import { getMd, Md } from "../api/getMd";
 
 interface ConcertTabPanelProps {
   concertId: number;
@@ -16,26 +17,28 @@ interface ConcertTabPanelProps {
 }
 
 function ConcertTabPanel({ concertId, ticketUrl }: ConcertTabPanelProps) {
-  const [mds, setMd] = useState<Md[] | null>(null);
-  const [mdCount, setMdCount] = useState(0);
+  const [schedules, setSchedule] = useState<Schedule[] | null>(null);
+
   const [concertRequiredInfo, setConcertRequiredInfo] = useState<
     ConcertRequired[] | null
   >(null);
+
+  const [mds, setMd] = useState<Md[] | null>(null);
+  const [mdCount, setMdCount] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
-    const fetchMds = async () => {
+    const fetchSchedule = async () => {
       try {
-        const data = await getMd(concertId);
-        setMd(data);
-        setMdCount(data.length);
+        const data = await getSchedule(concertId);
+        setSchedule(data);
       } catch (error) {
-        console.error("특정 콘서트의 MD 목록 조회 API 호출 실패:", error);
-        setMd([]);
+        console.error("특정 콘서트 일정 목록 조회 API 호출 실패:", error);
+        setSchedule([]);
       }
     };
 
-    fetchMds();
+    fetchSchedule();
   }, [concertId]);
 
   useEffect(() => {
@@ -52,13 +55,28 @@ function ConcertTabPanel({ concertId, ticketUrl }: ConcertTabPanelProps) {
     fetchConcertRequiredInfo();
   }, [concertId]);
 
+  useEffect(() => {
+    const fetchMds = async () => {
+      try {
+        const data = await getMd(concertId);
+        setMd(data);
+        setMdCount(data.length);
+      } catch (error) {
+        console.error("특정 콘서트의 MD 목록 조회 API 호출 실패:", error);
+        setMd([]);
+      }
+    };
+
+    fetchMds();
+  }, [concertId]);
+
   if (mds === null) {
     return null;
   }
 
   return (
     <>
-      {/* <ConcertSchedulePanel /> */}
+      {schedules && <ConcertSchedulePanel schedules={schedules} />}
 
       <div className="mx-16">
         <div className="pt-30 pb-20">

--- a/src/entities/concert/ui/ConcertTabPanel.tsx
+++ b/src/entities/concert/ui/ConcertTabPanel.tsx
@@ -1,124 +1,39 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import ConcertSchedulePanel from "../../../features/concert/ui/ConcertSchedulePanel";
-import ConcertInfoCarousel from "../../../widgets/ConcertInfoCarousel";
-import MdSlide from "../../../entities/concert/ui/MdSlide";
-import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
-import { getSchedule, Schedule } from "../api/getSchedule";
-import {
-  getConcertRequiredInfo,
-  ConcertRequired,
-} from "../api/getConcertRequiredInfo";
-import { getMd, Md } from "../api/getMd";
+import ScheduleInfo from "./ScheduleInfo";
+import RequiredInfo from "./RequiredInfo";
+import MdInfo from "./MdInfo";
+import { Schedule } from "../api/getSchedule";
+import { ConcertRequired } from "../api/getConcertRequiredInfo";
+import { Md } from "../api/getMd";
 
 interface ConcertTabPanelProps {
   concertId: number;
   ticketUrl: string;
+  schedules: Schedule[] | null;
+  concertRequiredInfo: ConcertRequired[] | null;
+  mds: Md[] | null;
 }
 
-function ConcertTabPanel({ concertId, ticketUrl }: ConcertTabPanelProps) {
-  const [schedules, setSchedule] = useState<Schedule[] | null>(null);
-
-  const [concertRequiredInfo, setConcertRequiredInfo] = useState<
-    ConcertRequired[] | null
-  >(null);
-
-  const [mds, setMd] = useState<Md[] | null>(null);
-  const [mdCount, setMdCount] = useState(0);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const fetchSchedule = async () => {
-      try {
-        const data = await getSchedule(concertId);
-        setSchedule(data);
-      } catch (error) {
-        console.error("특정 콘서트 일정 목록 조회 API 호출 실패:", error);
-        setSchedule([]);
-      }
-    };
-
-    fetchSchedule();
-  }, [concertId]);
-
-  useEffect(() => {
-    const fetchConcertRequiredInfo = async () => {
-      try {
-        const data = await getConcertRequiredInfo(concertId);
-        setConcertRequiredInfo(data);
-      } catch (error) {
-        console.error("특정 콘서트 필수 정보 목록 조회 API 호출 실패:", error);
-        setConcertRequiredInfo([]);
-      }
-    };
-
-    fetchConcertRequiredInfo();
-  }, [concertId]);
-
-  useEffect(() => {
-    const fetchMds = async () => {
-      try {
-        const data = await getMd(concertId);
-        setMd(data);
-        setMdCount(data.length);
-      } catch (error) {
-        console.error("특정 콘서트의 MD 목록 조회 API 호출 실패:", error);
-        setMd([]);
-      }
-    };
-
-    fetchMds();
-  }, [concertId]);
-
-  if (mds === null) {
-    return null;
-  }
-
+function ConcertTabPanel({
+  concertId,
+  ticketUrl,
+  schedules,
+  concertRequiredInfo,
+  mds,
+}: ConcertTabPanelProps) {
   return (
     <>
-      {schedules && <ConcertSchedulePanel schedules={schedules} />}
+      {schedules && schedules.length > 0 && (
+        <ScheduleInfo schedules={schedules} />
+      )}
 
-      <div className="mx-16">
-        <div className="pt-30 pb-20">
-          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
-            콘서트 필수 정보를
-            <br />
-            확인해 보세요
-          </p>
-        </div>
-        {concertRequiredInfo && (
-          <ConcertInfoCarousel
-            concertRequiredInfo={concertRequiredInfo}
-            ticketUrl={ticketUrl}
-          />
-        )}
-      </div>
+      {concertRequiredInfo && concertRequiredInfo.length > 0 && (
+        <RequiredInfo
+          concertRequiredInfo={concertRequiredInfo}
+          ticketUrl={ticketUrl}
+        />
+      )}
 
-      <div>
-        <div className="pt-30 pb-20 px-16 relative">
-          <div className="flex">
-            <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-4">
-              <p className="px-7 text-grayScaleBlack100 text-body-lg font-semibold font-NotoSansKR">
-                {mdCount}건
-              </p>
-            </div>
-            <p className="ml-4 text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
-              의 MD 정보를
-            </p>
-          </div>
-          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
-            한 눈에 확인하세요
-          </p>
-          <button
-            className="absolute bottom-20 right-16 w-24 h-24 bg-transparent border-none p-0 cursor-pointer"
-            onClick={() => navigate("/md", { state: { concertId } })}
-          >
-            <img src={ConcertRightArrow} className="w-full h-full" />
-          </button>
-        </div>
-
-        {mds.length > 0 && <MdSlide mds={mds} />}
-      </div>
+      {mds && <MdInfo mds={mds} concertId={concertId} mdCount={mds.length} />}
     </>
   );
 }

--- a/src/entities/concert/ui/ConcertTabPanel.tsx
+++ b/src/entities/concert/ui/ConcertTabPanel.tsx
@@ -5,14 +5,21 @@ import ConcertInfoCarousel from "../../../widgets/ConcertInfoCarousel";
 import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
 import MdSlide from "../../../entities/concert/ui/MdSlide";
 import { getMd, Md } from "../api/getMd";
+import {
+  getConcertRequiredInfo,
+  ConcertRequired,
+} from "../api/getConcertRequiredInfo";
 
-interface MdProps {
+interface ConcertTabPanelProps {
   concertId: number;
 }
 
-function ConcertTabPanel({ concertId }: MdProps) {
+function ConcertTabPanel({ concertId }: ConcertTabPanelProps) {
   const [mds, setMd] = useState<Md[] | null>(null);
   const [mdCount, setMdCount] = useState(0);
+  const [concertRequiredInfo, setConcertRequiredInfo] = useState<
+    ConcertRequired[] | null
+  >(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -28,6 +35,20 @@ function ConcertTabPanel({ concertId }: MdProps) {
     };
 
     fetchMds();
+  }, [concertId]);
+
+  useEffect(() => {
+    const fetchConcertRequiredInfo = async () => {
+      try {
+        const data = await getConcertRequiredInfo(concertId);
+        setConcertRequiredInfo(data);
+      } catch (error) {
+        console.error("특정 콘서트 필수 정보 목록 조회 API 호출 실패:", error);
+        setConcertRequiredInfo([]);
+      }
+    };
+
+    fetchConcertRequiredInfo();
   }, [concertId]);
 
   if (mds === null) {
@@ -46,7 +67,9 @@ function ConcertTabPanel({ concertId }: MdProps) {
             확인해 보세요
           </p>
         </div>
-        <ConcertInfoCarousel />
+        {concertRequiredInfo && (
+          <ConcertInfoCarousel concertRequiredInfo={concertRequiredInfo} />
+        )}
       </div>
 
       <div>

--- a/src/entities/concert/ui/ConcertTabPanel.tsx
+++ b/src/entities/concert/ui/ConcertTabPanel.tsx
@@ -3,30 +3,32 @@ import { useEffect, useState } from "react";
 import ConcertInfoCarousel from "../../../widgets/ConcertInfoCarousel";
 import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
 import MdSlide from "../../../entities/concert/ui/MdSlide";
+import { getMd, Md } from "../api/getMd";
 
-import { ConcertFilter, Concert } from "../../../entities/concert/types";
-import { getConcertList } from "../../../features/concert/api/getConcertList";
+interface MdProps {
+  concertId: number;
+}
 
-function ConcertTabPanel() {
-  // 추후 콘서트 api 대신 MD api 연결
-  const [concerts, setConcerts] = useState<Concert[] | null>(null);
+function ConcertTabPanel({ concertId }: MdProps) {
+  const [mds, setMd] = useState<Md[] | null>(null);
+  const [mdCount, setMdCount] = useState(0);
+
   useEffect(() => {
-    const fetchConcerts = async () => {
+    const fetchMds = async () => {
       try {
-        const res = await getConcertList({
-          filter: ConcertFilter.UPCOMING,
-          size: 10,
-        });
-        setConcerts(res.data.data);
+        const data = await getMd(concertId);
+        setMd(data);
+        setMdCount(data.length);
       } catch (error) {
-        console.error("콘서트 목록 조회 API 호출 실패:", error);
-        setConcerts([]);
+        console.error("특정 콘서트의 MD 목록 조회 API 호출 실패:", error);
+        setMd([]);
       }
     };
 
-    fetchConcerts();
-  }, []);
-  if (concerts === null) {
+    fetchMds();
+  }, [concertId]);
+
+  if (mds === null) {
     return null;
   }
 
@@ -50,7 +52,7 @@ function ConcertTabPanel() {
           <div className="flex">
             <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-4">
               <p className="px-7 text-grayScaleBlack100 text-body-lg font-semibold font-NotoSansKR">
-                8건
+                {mdCount}건
               </p>
             </div>
             <p className="ml-4 text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
@@ -65,7 +67,7 @@ function ConcertTabPanel() {
           </button>
         </div>
 
-        <MdSlide filter={ConcertFilter.UPCOMING} concerts={concerts} />
+        {mds.length > 0 && <MdSlide mds={mds} />}
       </div>
     </>
   );

--- a/src/entities/concert/ui/ConcertTabPanel.tsx
+++ b/src/entities/concert/ui/ConcertTabPanel.tsx
@@ -12,9 +12,10 @@ import {
 
 interface ConcertTabPanelProps {
   concertId: number;
+  ticketUrl: string;
 }
 
-function ConcertTabPanel({ concertId }: ConcertTabPanelProps) {
+function ConcertTabPanel({ concertId, ticketUrl }: ConcertTabPanelProps) {
   const [mds, setMd] = useState<Md[] | null>(null);
   const [mdCount, setMdCount] = useState(0);
   const [concertRequiredInfo, setConcertRequiredInfo] = useState<
@@ -68,7 +69,10 @@ function ConcertTabPanel({ concertId }: ConcertTabPanelProps) {
           </p>
         </div>
         {concertRequiredInfo && (
-          <ConcertInfoCarousel concertRequiredInfo={concertRequiredInfo} />
+          <ConcertInfoCarousel
+            concertRequiredInfo={concertRequiredInfo}
+            ticketUrl={ticketUrl}
+          />
         )}
       </div>
 

--- a/src/entities/concert/ui/FanCultureInfo.tsx
+++ b/src/entities/concert/ui/FanCultureInfo.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import FanCultureSwiper from "./FanCultureSwiper";
+
+interface FanCultureInfoProps {
+  concertId: number;
+}
+
+function FanCultureInfo({ concertId }: FanCultureInfoProps) {
+  const [cultureCount, setCultureCount] = useState(0);
+
+  return (
+    <>
+      <div className="mx-16">
+        <div className="pt-24 pb-20">
+          <div className="flex">
+            <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-4">
+              <p className="px-7 text-grayScaleBlack100 text-body-lg font-semibold font-NotoSansKR">
+                {cultureCount}개
+              </p>
+            </div>
+            <p className="ml-4 text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+              의 팬문화와
+            </p>
+          </div>
+          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+            꿀팁을 한 눈에 알아봐요
+          </p>
+        </div>
+      </div>
+      <FanCultureSwiper
+        concertId={concertId}
+        onCultureCountChange={setCultureCount}
+      />
+    </>
+  );
+}
+
+export default FanCultureInfo;

--- a/src/entities/concert/ui/FanCultureInfo.tsx
+++ b/src/entities/concert/ui/FanCultureInfo.tsx
@@ -1,13 +1,12 @@
-import { useState } from "react";
 import FanCultureSwiper from "./FanCultureSwiper";
+import { ConcertCulture } from "../api/getConcertCulture";
 
 interface FanCultureInfoProps {
-  concertId: number;
+  concertCulture: ConcertCulture[];
+  cultureCount: number;
 }
 
-function FanCultureInfo({ concertId }: FanCultureInfoProps) {
-  const [cultureCount, setCultureCount] = useState(0);
-
+function FanCultureInfo({ concertCulture, cultureCount }: FanCultureInfoProps) {
   return (
     <>
       <div className="mx-16">
@@ -27,10 +26,7 @@ function FanCultureInfo({ concertId }: FanCultureInfoProps) {
           </p>
         </div>
       </div>
-      <FanCultureSwiper
-        concertId={concertId}
-        onCultureCountChange={setCultureCount}
-      />
+      <FanCultureSwiper concertCulture={concertCulture} />
     </>
   );
 }

--- a/src/entities/concert/ui/FanCultureSwiper.tsx
+++ b/src/entities/concert/ui/FanCultureSwiper.tsx
@@ -6,14 +6,13 @@ import "swiper/css";
 import "swiper/css/free-mode";
 import ConcertSlidePrevArrow from "../../../shared/assets/ConcertSlidePrevArrow.svg";
 import ConcertSlideNextArrow from "../../../shared/assets/ConcertSlideNextArrow.svg";
-import { getConcertCulture, ConcertCulture } from "../api/getConcertCulture";
+import { ConcertCulture } from "../api/getConcertCulture";
 
-interface Props {
-  concertId: number;
-  onCultureCountChange?: (count: number) => void;
+interface FanCultureSwiperProps {
+  concertCulture: ConcertCulture[];
 }
 
-function FanCultureSwiper({ concertId, onCultureCountChange }: Props) {
+function FanCultureSwiper({ concertCulture }: FanCultureSwiperProps) {
   const navigate = useNavigate();
   const [isHovered, setIsHovered] = useState(false);
   const [isBeginning, setIsBeginning] = useState(true);
@@ -32,24 +31,6 @@ function FanCultureSwiper({ concertId, onCultureCountChange }: Props) {
       swiperRef.current.slideTo(swiperRef.current.activeIndex - slidesToScroll);
     }
   };
-
-  const [ConcertCulture, setConcertCulture] = useState<ConcertCulture[]>([]);
-
-  useEffect(() => {
-    const fetchConcertCulture = async () => {
-      try {
-        const data = await getConcertCulture(concertId);
-        setConcertCulture(data);
-        if (onCultureCountChange) {
-          onCultureCountChange(data.length);
-        }
-      } catch (error) {
-        console.error("특정 콘서트 공연 문화 목록 조회 API 호출 실패:", error);
-      }
-    };
-
-    fetchConcertCulture();
-  }, [concertId]);
 
   useEffect(() => {
     if (!swiperRef.current) return;
@@ -80,7 +61,7 @@ function FanCultureSwiper({ concertId, onCultureCountChange }: Props) {
 
   useEffect(() => {
     // 데이터 받아오고 카드 높이 맞추기
-    if (ConcertCulture.length === 0) return;
+    if (concertCulture.length === 0) return;
 
     requestAnimationFrame(() => {
       const heights = cardRefs.current.map((el) => el?.offsetHeight || 0);
@@ -90,7 +71,7 @@ function FanCultureSwiper({ concertId, onCultureCountChange }: Props) {
         if (el) el.style.height = `${maxHeight}px`;
       });
     });
-  }, [ConcertCulture]);
+  }, [concertCulture]);
 
   return (
     <div
@@ -139,7 +120,7 @@ function FanCultureSwiper({ concertId, onCultureCountChange }: Props) {
           setIsEnd(swiper.isEnd);
         }}
       >
-        {ConcertCulture.map((culture, i) => (
+        {concertCulture.map((culture, i) => (
           <SwiperSlide key={i} style={{ width: 228 }}>
             <div
               ref={(el) => {

--- a/src/entities/concert/ui/MdCard.tsx
+++ b/src/entities/concert/ui/MdCard.tsx
@@ -1,0 +1,32 @@
+type MdCardProps = {
+  name: string;
+  price: string;
+  imgUrl: string;
+  onClick?: () => void;
+};
+
+function MdCard({ name, price, imgUrl, onClick }: MdCardProps) {
+  return (
+    <div onClick={onClick} className="cursor-pointer">
+      <div className="w-full aspect-[108/158] relative">
+        {imgUrl ? (
+          <img
+            src={imgUrl}
+            alt="MD 이미지"
+            className="w-full h-full rounded-6 object-cover"
+          />
+        ) : (
+          <div className="w-full bg-grayScaleBlack80 rounded-6" />
+        )}
+      </div>
+      <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR mt-8 line-clamp-2">
+        {name}
+      </p>
+      <p className="text-grayScaleBlack30 text-caption-lg font-semibold font-NotoSansKR mt-10 line-clamp-1">
+        {price}
+      </p>
+    </div>
+  );
+}
+
+export default MdCard;

--- a/src/entities/concert/ui/MdInfo.tsx
+++ b/src/entities/concert/ui/MdInfo.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from "react-router-dom";
+import MdSlide from "../../../entities/concert/ui/MdSlide";
+import ConcertRightArrow from "../../../shared/assets/ConcertRightArrow.svg";
+import { Md } from "../api/getMd";
+
+type MdInfoProps = {
+  concertId: number;
+  mds: Md[];
+  mdCount: number;
+};
+
+function MdInfo({ mds, concertId, mdCount }: MdInfoProps) {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <div>
+        <div className="pt-30 pb-20 px-16 relative">
+          <div className="flex">
+            <div className="inline-flex items-center justify-center bg-mainYellow30 rounded-4">
+              <p className="px-7 text-grayScaleBlack100 text-body-lg font-semibold font-NotoSansKR">
+                {mdCount}건
+              </p>
+            </div>
+            <p className="ml-4 text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+              의 MD 정보를
+            </p>
+          </div>
+          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+            한 눈에 확인하세요
+          </p>
+          <button
+            className="absolute bottom-20 right-16 w-24 h-24 bg-transparent border-none p-0 cursor-pointer"
+            onClick={() => navigate("/md", { state: { concertId } })}
+          >
+            <img src={ConcertRightArrow} className="w-full h-full" />
+          </button>
+        </div>
+
+        {mds.length > 0 && <MdSlide mds={mds} />}
+      </div>
+    </>
+  );
+}
+
+export default MdInfo;

--- a/src/entities/concert/ui/MdSlide.tsx
+++ b/src/entities/concert/ui/MdSlide.tsx
@@ -7,28 +7,19 @@ import "swiper/css/free-mode";
 import MdSlideCard from "./MdSlideCard";
 import ConcertSlidePrevArrow from "../../../shared/assets/ConcertSlidePrevArrow.svg";
 import ConcertSlideNextArrow from "../../../shared/assets/ConcertSlideNextArrow.svg";
-import EmptyConcertSlide from "../../../features/concert/ui/EmptyConcertSlide";
-import { ConcertFilter, Concert } from "../types";
-import { formatConcertDate } from "../../../shared/utils/formatConcertDate";
+import { Md } from "../api/getMd";
 
-// 추후 콘서트 api 대신 MD api 연결
-
-type ConcertSlideProps = {
-  filter: ConcertFilter;
-  concerts: Concert[];
+type MdSlideProps = {
+  mds: Md[];
 };
 
-function MdSlide({ filter, concerts }: ConcertSlideProps) {
+function MdSlide({ mds }: MdSlideProps) {
   const navigate = useNavigate();
   const [isHovered, setIsHovered] = useState(false);
   const [isBeginning, setIsBeginning] = useState(true);
   const [isEnd, setIsEnd] = useState(false);
   const swiperRef = useRef<any>(null);
   const slidesToScroll = 2;
-
-  if (concerts.length === 0) {
-    return <EmptyConcertSlide filter={filter} />;
-  }
 
   const goNext = () => {
     if (swiperRef.current) {
@@ -114,18 +105,9 @@ function MdSlide({ filter, concerts }: ConcertSlideProps) {
           setIsEnd(swiper.isEnd);
         }}
       >
-        {concerts.map((concert) => (
-          <SwiperSlide key={concert.id} style={{ width: 108 }}>
-            <MdSlideCard
-              imageUrl={concert.poster}
-              title={concert.title}
-              date={formatConcertDate(concert.startDate, concert.endDate)}
-              filter={filter}
-              daysLeft={concert.daysLeft}
-              onClick={() =>
-                navigate(`/concert/${concert.id}`, { state: { filter } })
-              }
-            />
+        {mds.map((md) => (
+          <SwiperSlide key={md.id} style={{ width: 108 }}>
+            <MdSlideCard name={md.name} price={md.price} imageUrl={md.imgUrl} />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/entities/concert/ui/MdSlideCard.tsx
+++ b/src/entities/concert/ui/MdSlideCard.tsx
@@ -1,38 +1,17 @@
-import { ConcertFilter } from "../types";
-
-// 추후 콘서트 api 대신 MD api 연결
-
-type ConcertSlideCardProps = {
+type MdSlideCardProps = {
+  name: string;
+  price: string;
   imageUrl?: string;
-  title: string;
-  date: string;
-  filter: ConcertFilter;
-  daysLeft: number;
-  onClick?: () => void;
 };
 
-function MdSlideCard({
-  imageUrl,
-  title,
-  date,
-  filter,
-  daysLeft,
-  onClick,
-}: ConcertSlideCardProps) {
-  const filterText =
-    filter === ConcertFilter.NEW
-      ? "진행중"
-      : filter === ConcertFilter.ALL
-        ? "종료"
-        : `D-${daysLeft}`;
-
+function MdSlideCard({ name, price, imageUrl }: MdSlideCardProps) {
   return (
-    <div className="w-108 h-214 cursor-pointer" onClick={onClick}>
+    <div className="w-108 h-214 cursor-pointer">
       <div className="w-108 h-158 relative">
         {imageUrl ? (
           <img
             src={imageUrl}
-            alt="콘서트 이미지"
+            alt="MD 이미지"
             className="w-full h-full rounded-6 object-cover"
           />
         ) : (
@@ -40,10 +19,10 @@ function MdSlideCard({
         )}
       </div>
       <p className="mt-8 mb-0 text-grayScaleWhite text-body-md font-medium font-NotoSansKR line-clamp-1">
-        {title}
+        {name}
       </p>
       <p className="mt-10 mb-0 text-grayScaleBlack30 text-caption-lg font-semibold font-NotoSansKR line-clamp-1">
-        {date}
+        {price}
       </p>
     </div>
   );

--- a/src/entities/concert/ui/RequiredInfo.tsx
+++ b/src/entities/concert/ui/RequiredInfo.tsx
@@ -1,0 +1,31 @@
+import ConcertInfoCarousel from "../../../widgets/ConcertInfoCarousel";
+import { ConcertRequired } from "../api/getConcertRequiredInfo";
+
+type RequiredInfoProps = {
+  concertRequiredInfo: ConcertRequired[];
+  ticketUrl: string;
+};
+
+function RequiredInfo({ concertRequiredInfo, ticketUrl }: RequiredInfoProps) {
+  return (
+    <>
+      <div className="mx-16">
+        <div className="pt-30 pb-20">
+          <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+            콘서트 필수 정보를
+            <br />
+            확인해 보세요
+          </p>
+        </div>
+        {concertRequiredInfo && (
+          <ConcertInfoCarousel
+            concertRequiredInfo={concertRequiredInfo}
+            ticketUrl={ticketUrl}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+export default RequiredInfo;

--- a/src/entities/concert/ui/ScheduleInfo.tsx
+++ b/src/entities/concert/ui/ScheduleInfo.tsx
@@ -1,12 +1,15 @@
-import { Schedule } from "../../../entities/concert/api/getSchedule";
+import { Schedule } from "../api/getSchedule";
 import dayjs from "../../../shared/lib/dayjs";
-import { getFormatDday, getFormatDateTime } from "../utils/formatScheduleDate";
+import {
+  getFormatDday,
+  getFormatDateTime,
+} from "../../../features/concert/utils/formatScheduleDate";
 
-type ConcertSchedulePanelProps = {
+type ScheduleInfoProps = {
   schedules: Schedule[];
 };
 
-function ConcertSchedulePanel({ schedules }: ConcertSchedulePanelProps) {
+function ScheduleInfo({ schedules }: ScheduleInfoProps) {
   const concertSchedules = schedules.filter((s) => s.category === "공연");
 
   const upcomingSchedules = schedules
@@ -21,7 +24,7 @@ function ConcertSchedulePanel({ schedules }: ConcertSchedulePanelProps) {
 
   return (
     <div className="pt-20 pl-16 pr-16">
-      <div className="pb-190 flex flex-col gap-12">
+      <div className="flex flex-col gap-12">
         {sortedSchedules.map((schedule) => {
           const isPast = dayjs(schedule.scheduledAt).isBefore(dayjs(), "day");
           const dday = getFormatDday(schedule.scheduledAt);
@@ -68,4 +71,4 @@ function ConcertSchedulePanel({ schedules }: ConcertSchedulePanelProps) {
   );
 }
 
-export default ConcertSchedulePanel;
+export default ScheduleInfo;

--- a/src/features/concert/ui/ConcertSchedulePanel.tsx
+++ b/src/features/concert/ui/ConcertSchedulePanel.tsx
@@ -1,48 +1,68 @@
-function ConcertSchedulePanel() {
+import { Schedule } from "../../../entities/concert/api/getSchedule";
+import dayjs from "../../../shared/lib/dayjs";
+import { getFormatDday, getFormatDateTime } from "../utils/formatScheduleDate";
+
+type ConcertSchedulePanelProps = {
+  schedules: Schedule[];
+};
+
+function ConcertSchedulePanel({ schedules }: ConcertSchedulePanelProps) {
+  const concertSchedules = schedules.filter((s) => s.category === "공연");
+
+  const upcomingSchedules = schedules
+    .filter((s) => dayjs(s.scheduledAt).isSameOrAfter(dayjs(), "day"))
+    .sort((a, b) => dayjs(a.scheduledAt).unix() - dayjs(b.scheduledAt).unix());
+
+  const pastSchedules = schedules
+    .filter((s) => dayjs(s.scheduledAt).isBefore(dayjs(), "day"))
+    .sort((a, b) => dayjs(a.scheduledAt).unix() - dayjs(b.scheduledAt).unix());
+
+  const sortedSchedules = [...upcomingSchedules, ...pastSchedules];
+
   return (
     <div className="pt-20 pl-16 pr-16">
       <div className="pb-190 flex flex-col gap-12">
-        <div className="flex items-center justify-between pl-15 pr-16 w-full h-64 bg-grayScaleBlack90 rounded-8 border border-solid border-grayScaleBlack80">
-          <div className="flex items-center">
-            <div className="h-30 px-13 py-8 bg-mainYellow30 rounded-24 text-grayScaleBlack100 text-caption-lg font-semibold font-NotoSansKR">
-              D-60
-            </div>
-            <p className="pl-8 text-grayScaleWhite text-body-sm font-semibold font-NotoSansKR">
-              09.13 (토) 콘서트
-            </p>
-          </div>
-          <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
-            9/13(토) 2:00PM
-          </p>
-        </div>
+        {sortedSchedules.map((schedule) => {
+          const isPast = dayjs(schedule.scheduledAt).isBefore(dayjs(), "day");
+          const dday = getFormatDday(schedule.scheduledAt);
+          const date = getFormatDateTime(schedule.scheduledAt);
 
-        <div className="flex items-center justify-between pl-15 pr-16 w-full h-64 bg-grayScaleBlack90 rounded-8 border border-solid border-grayScaleBlack80">
-          <div className="flex items-center">
-            <div className="h-30 px-13 py-8 bg-mainYellow30 rounded-24 text-grayScaleBlack100 text-caption-lg font-semibold font-NotoSansKR">
-              D-61
-            </div>
-            <p className="pl-8 text-grayScaleWhite text-body-sm font-semibold font-NotoSansKR">
-              09.14 (일) 콘서트
-            </p>
-          </div>
-          <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
-            9/14(일) 2:00PM
-          </p>
-        </div>
+          // 콘서트 일차 표기
+          let content = schedule.category;
+          if (schedule.category === "공연") {
+            const index = concertSchedules.findIndex(
+              (c) => c.id === schedule.id
+            );
+            if (concertSchedules.length > 1 && index !== -1) {
+              // 공연 일정이 2개 이상일 경우 n일차 콘서트 표기
+              content = `${index + 1}일차 콘서트`;
+            } else {
+              // 공연이 단 하나일 경우 표기
+              content = "콘서트";
+            }
+          }
 
-        <div className="flex items-center justify-between pl-15 pr-16 w-full h-64 bg-grayScaleBlack90 rounded-8 border border-solid border-grayScaleBlack80 opacity-30">
-          <div className="flex items-center">
-            <div className="h-30 px-13 py-8 bg-mainYellow30 rounded-24 text-grayScaleBlack100 text-caption-lg font-semibold font-NotoSansKR">
-              D-120
+          return (
+            <div
+              key={schedule.id}
+              className={`flex items-center justify-between pl-15 pr-16 w-full h-64 bg-grayScaleBlack90 rounded-8 border border-solid border-grayScaleBlack80 ${
+                isPast ? "opacity-30" : ""
+              }`}
+            >
+              <div className="flex items-center">
+                <div className="h-30 px-13 py-8 bg-mainYellow30 rounded-24 text-grayScaleBlack100 text-caption-lg font-semibold font-NotoSansKR">
+                  {dday}
+                </div>
+                <p className="pl-8 text-grayScaleWhite text-body-sm font-semibold font-NotoSansKR">
+                  {content}
+                </p>
+              </div>
+              <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
+                {date}
+              </p>
             </div>
-            <p className="pl-8 text-grayScaleWhite text-body-sm font-semibold font-NotoSansKR">
-              티켓팅 오픈
-            </p>
-          </div>
-          <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
-            9/14(일) 2:00PM
-          </p>
-        </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/features/concert/ui/ConcertSetting.tsx
+++ b/src/features/concert/ui/ConcertSetting.tsx
@@ -7,8 +7,8 @@ import Tab from "@mui/material/Tab";
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
-import ConcertSchedulePanel from "./ConcertSchedulePanel";
 import EmptyConcertSchedulePanel from "./EmptyConcertSchedulePanel";
+import ScheduleInfo from "../../../entities/concert/ui/ScheduleInfo";
 
 function ConcertSetting() {
   const [tabValue, setTabValue] = useState("1");
@@ -145,7 +145,7 @@ function ConcertSetting() {
               <br />
               확인해 보세요!
             </div>
-            <ConcertSchedulePanel />
+            <ScheduleInfo />
             {/* <EmptyConcertSchedulePanel /> */}
           </TabPanel>
           <TabPanel

--- a/src/features/concert/utils/formatScheduleDate.ts
+++ b/src/features/concert/utils/formatScheduleDate.ts
@@ -1,0 +1,22 @@
+import dayjs from "dayjs";
+
+export function getFormatDday(scheduledAt: string): string {
+  const today = dayjs().startOf("day");
+  const target = dayjs(scheduledAt).startOf("day");
+  const diff = target.diff(today, "day");
+
+  if (diff === 0) return "D-DAY";
+  if (diff > 0) return `D-${diff}`;
+  return `D+${Math.abs(diff)}`;
+}
+
+export function getFormatDateTime(scheduledAt: string): string {
+  const date = dayjs(scheduledAt);
+  const dayMap = ["일", "월", "화", "수", "목", "금", "토"];
+  const day = dayMap[date.day()];
+
+  const hasTime = date.hour() !== 0 || date.minute() !== 0;
+  return hasTime
+    ? `${date.format("M/D")}(${day}) ${date.format("h:mmA")}`
+    : `${date.format("M/D")}(${day})`;
+}

--- a/src/pages/ConcertInsidePage.tsx
+++ b/src/pages/ConcertInsidePage.tsx
@@ -1,61 +1,48 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import ListHeader from "../shared/ui/ListHeader";
 import ConcertInsideInfo from "../entities/concert/ui/ConcertInsideInfo";
-import PastSetList from "../widgets/PastSetList";
-import ExpectationSetList from "../widgets/ExpectationSetList";
-import { ConcertFilter } from "../entities/concert/types";
-import OngoingSetList from "../widgets/OngoingSetList";
 import ConcertInfoTab from "../entities/concert/ui/ConcertInfoTab";
+import { getConcertInsideInfo } from "../entities/concert/api/getConcertInsideInfo";
+import { Concert } from "../entities/concert/types";
+// import PastSetList from "../widgets/PastSetList";
+// import ExpectationSetList from "../widgets/ExpectationSetList";
+// import OngoingSetList from "../widgets/OngoingSetList";
 
 function ConcertInsidePage() {
   const { concertId } = useParams<{ concertId: string }>();
   const location = useLocation();
   const status = location.state?.status;
 
+  const [concert, setConcert] = useState<Concert | null>(null);
+
   // 페이지 진입 시 스크롤 맨 위로 이동
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
+  useEffect(() => {
+    async function fetchConcert() {
+      try {
+        const data = await getConcertInsideInfo(Number(concertId));
+        setConcert(data);
+      } catch (error) {
+        console.error("특정 콘서트 상세 정보 조회 API 호출 실패", error);
+      }
+    }
+
+    fetchConcert();
+  }, [concertId]);
+
+  if (!concert) return null;
+
   return (
     <div>
       <ListHeader title={"공연 상세정보"} />
-      <ConcertInsideInfo concertId={Number(concertId)}></ConcertInsideInfo>
+      <ConcertInsideInfo concert={concert}></ConcertInsideInfo>
       <ConcertInfoTab concertId={Number(concertId)}></ConcertInfoTab>
     </div>
   );
 }
 
 export default ConcertInsidePage;
-
-// function ConcertInsidePage() {
-//   const { concertId } = useParams<{ concertId: string }>();
-//   const location = useLocation();
-//   const status = location.state?.status;
-
-//   // 페이지 진입 시 스크롤 맨 위로 이동
-//   useEffect(() => {
-//     window.scrollTo(0, 0);
-//   }, []);
-
-//   return (
-//     <div className="pb-64">
-//       <ListHeader></ListHeader>
-//       <ConcertInsideInfo concertId={Number(concertId)}></ConcertInsideInfo>
-//       <ConcertCulture></ConcertCulture>
-//       {status === ConcertStatus.UPCOMING ? (
-//         <>
-//           <ExpectationSetList
-//             concertId={Number(concertId)}
-//           ></ExpectationSetList>
-//           <PastSetList concertId={Number(concertId)}></PastSetList>
-//         </>
-//       ) : (
-//         <OngoingSetList concertId={Number(concertId)}></OngoingSetList>
-//       )}
-//     </div>
-//   );
-// }
-
-// export default ConcertInsidePage;

--- a/src/pages/ConcertInsidePage.tsx
+++ b/src/pages/ConcertInsidePage.tsx
@@ -40,7 +40,10 @@ function ConcertInsidePage() {
     <div>
       <ListHeader title={"공연 상세정보"} />
       <ConcertInsideInfo concert={concert}></ConcertInsideInfo>
-      <ConcertInfoTab concertId={Number(concertId)}></ConcertInfoTab>
+      <ConcertInfoTab
+        concertId={Number(concertId)}
+        ticketUrl={concert.ticketUrl}
+      ></ConcertInfoTab>
     </div>
   );
 }

--- a/src/pages/MdPage.tsx
+++ b/src/pages/MdPage.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import ListHeader from "../shared/ui/ListHeader";
+import MdList from "../widgets/MdList";
+
+function MdPage() {
+  const location = useLocation();
+  const concertId = location.state?.concertId;
+
+  // 페이지 진입 시 스크롤 맨 위로 이동
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <div className="pb-90">
+      <ListHeader title={"MD 상세보기"} />
+      <MdList concertId={concertId} />
+    </div>
+  );
+}
+
+export default MdPage;

--- a/src/shared/lib/dayjs.ts
+++ b/src/shared/lib/dayjs.ts
@@ -1,0 +1,6 @@
+import dayjs from "dayjs";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
+
+dayjs.extend(isSameOrAfter);
+
+export default dayjs;

--- a/src/widgets/ConcertInfoCarousel.tsx
+++ b/src/widgets/ConcertInfoCarousel.tsx
@@ -7,31 +7,18 @@ import "../shared/styles/slick-theme.css";
 import PrevArrow from "../shared/assets/PrevArrow.svg";
 import NextArrow from "../shared/assets/NextArrow.svg";
 import { getBanner } from "../features/concert/api/getBanner";
+import { ConcertRequired } from "../entities/concert/api/getConcertRequiredInfo";
 
-type BannerProps = {
-  id: number;
-  title: string;
-  category: string;
-  imgUrl: string;
+type ConcertInfoCarouselProps = {
+  concertRequiredInfo: ConcertRequired[];
 };
 
-function ConcertInfoCarousel() {
+function ConcertInfoCarousel({
+  concertRequiredInfo,
+}: ConcertInfoCarouselProps) {
   // pc일 경우 마우스 hover시 캐러셀 전환 버튼 나타나도록
   const [isHovered, setIsHovered] = useState(false);
-  const [banners, setBanners] = useState<BannerProps[]>([]);
-
-  useEffect(() => {
-    const fetchBanners = async () => {
-      try {
-        const data = await getBanner();
-        setBanners(data);
-      } catch (error) {
-        console.error("배너 조회 API 호출 실패:", error);
-      }
-    };
-
-    fetchBanners();
-  }, []);
+  const [banners, setBanners] = useState<ConcertInfoCarouselProps[]>([]);
 
   const CustomPrevArrow = (props: any) => {
     const { onClick, style } = props;
@@ -82,11 +69,11 @@ function ConcertInfoCarousel() {
       onMouseLeave={() => setIsHovered(false)}
     >
       <Slider {...settings}>
-        {banners.map((slide) => (
+        {concertRequiredInfo.map((slide) => (
           <ConcertInfoCarouselSlide
             key={slide.id}
             category={slide.category}
-            title={slide.title}
+            content={slide.content}
             imageUrl={slide.imgUrl}
           />
         ))}

--- a/src/widgets/ConcertInfoCarousel.tsx
+++ b/src/widgets/ConcertInfoCarousel.tsx
@@ -6,19 +6,19 @@ import ConcertInfoCarouselSlide from "./ConcertInfoCarouselSlide";
 import "../shared/styles/slick-theme.css";
 import PrevArrow from "../shared/assets/PrevArrow.svg";
 import NextArrow from "../shared/assets/NextArrow.svg";
-import { getBanner } from "../features/concert/api/getBanner";
 import { ConcertRequired } from "../entities/concert/api/getConcertRequiredInfo";
 
 type ConcertInfoCarouselProps = {
   concertRequiredInfo: ConcertRequired[];
+  ticketUrl: string;
 };
 
 function ConcertInfoCarousel({
   concertRequiredInfo,
+  ticketUrl,
 }: ConcertInfoCarouselProps) {
   // pc일 경우 마우스 hover시 캐러셀 전환 버튼 나타나도록
   const [isHovered, setIsHovered] = useState(false);
-  const [banners, setBanners] = useState<ConcertInfoCarouselProps[]>([]);
 
   const CustomPrevArrow = (props: any) => {
     const { onClick, style } = props;
@@ -75,6 +75,7 @@ function ConcertInfoCarousel({
             category={slide.category}
             content={slide.content}
             imageUrl={slide.imgUrl}
+            ticketUrl={ticketUrl}
           />
         ))}
       </Slider>

--- a/src/widgets/ConcertInfoCarouselSlide.tsx
+++ b/src/widgets/ConcertInfoCarouselSlide.tsx
@@ -2,13 +2,13 @@ import ConcertInfoCarouselArrow from "../shared/assets/ConcertInfoCarouselArrow.
 
 type MainImageCarouselSlideProps = {
   category: string;
-  title: string;
+  content: string;
   imageUrl: string;
 };
 
 function ConcertInfoCarouselSlide({
   category,
-  title,
+  content,
   imageUrl,
 }: MainImageCarouselSlideProps) {
   return (
@@ -16,7 +16,7 @@ function ConcertInfoCarouselSlide({
       <div className="h-365 absolute inset-0 bg-gradient-to-t from-grayScaleBlack100 to-transparent opacity-50"></div>
       <img
         src={imageUrl}
-        alt={title}
+        alt={content}
         className="w-full h-full object-cover rounded-8"
       />
       <button className="absolute top-26 left-26 w-30 h-30 w-30 bg-transparent border-none cursor-pointer">
@@ -33,7 +33,7 @@ function ConcertInfoCarouselSlide({
           </p>
         </div>
         <p className="pt-10 text-grayScaleWhite text-body-sm font-semibold font-NotoSansKR">
-          {title}
+          {content}
         </p>
       </div>
     </div>

--- a/src/widgets/ConcertInfoCarouselSlide.tsx
+++ b/src/widgets/ConcertInfoCarouselSlide.tsx
@@ -4,15 +4,23 @@ type MainImageCarouselSlideProps = {
   category: string;
   content: string;
   imageUrl: string;
+  ticketUrl: string;
 };
 
 function ConcertInfoCarouselSlide({
   category,
   content,
   imageUrl,
+  ticketUrl,
 }: MainImageCarouselSlideProps) {
+  const handleClick = () => {
+    if (ticketUrl) {
+      window.open(ticketUrl, "_blank");
+    }
+  };
+
   return (
-    <div className="relative w-full h-274">
+    <div className="relative w-full h-274" onClick={handleClick}>
       <div className="h-365 absolute inset-0 bg-gradient-to-t from-grayScaleBlack100 to-transparent opacity-50"></div>
       <img
         src={imageUrl}

--- a/src/widgets/MdList.tsx
+++ b/src/widgets/MdList.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import MdCard from "../entities/concert/ui/MdCard";
+import { getMd, Md } from "../entities/concert/api/getMd";
+
+interface MdListProps {
+  concertId?: number;
+}
+
+export function MdList({ concertId }: MdListProps) {
+  const [mds, setMd] = useState<Md[] | null>(null);
+
+  useEffect(() => {
+    const fetchMds = async () => {
+      if (!concertId) return;
+      try {
+        const data = await getMd(concertId);
+        setMd(data);
+      } catch (error) {
+        console.error("특정 콘서트의 MD 목록 조회 API 호출 실패:", error);
+        setMd([]);
+      }
+    };
+
+    fetchMds();
+  }, [concertId]);
+
+  return (
+    <div className="mt-18 grid grid-cols-3 gap-x-10 gap-y-24 mx-16">
+      {mds?.map((md) => (
+        <div key={md.id}>
+          <MdCard imgUrl={md.imgUrl} name={md.name} price={md.price} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default MdList;


### PR DESCRIPTION
### 📌 이슈 번호

- Closes #85

### 📌 PR 유형

- [x] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

### 📌 PR 내용

1. 특정 콘서트 일정 목록 조회 api 연결
2. 특정 콘서트 필수 정보 목록 조회 api 연결
3. 특정 콘서트의 MD 목록 조회 api 연결
4. ArtistTabPanel, ConcertTabPanel의 api 호출 위치 수정
5. ArtistTabPanel, ConcertTabPanel의 컴포넌트 분리
6. ArtistTabPanel, ConcertTabPanel의 엠티뷰 렌더링 조건 추가