### PR TITLE
[Feat/#90] 공연 상세 셋리스트 정보

### DIFF
--- a/src/entities/concert/api/getSetlistInfo.ts
+++ b/src/entities/concert/api/getSetlistInfo.ts
@@ -1,0 +1,21 @@
+import { ApiResponse } from "../../../shared/types/response";
+import axiosInstance from "../../../shared/api/axiosInstance";
+
+export type Setlist = {
+  id: number;
+  title: string;
+  imgUrl: string;
+  type: string;
+  startDate: string;
+  endDate: string;
+  status: string;
+  venue: string;
+  artist: string;
+};
+
+export async function getSetlistInfo(id: number): Promise<Setlist[]> {
+  const response = await axiosInstance.get<ApiResponse<Setlist[]>>(
+    `/api/v2/concerts/${id}/setlists`
+  );
+  return response.data.data;
+}

--- a/src/entities/concert/ui/ConcertInfoTab.tsx
+++ b/src/entities/concert/ui/ConcertInfoTab.tsx
@@ -218,7 +218,11 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
           )}
         </TabPanel>
         <TabPanel value="setlist" className="p-0">
-          <SetlistTabPanel setlist={setlist} />
+          {setlist && setlist.length > 0 ? (
+            <SetlistTabPanel setlist={setlist} />
+          ) : (
+            <EmptyConcertInfoTabPanel text={"셋리스트"} />
+          )}
         </TabPanel>
       </TabsBody>
     </Tabs>

--- a/src/entities/concert/ui/ConcertInfoTab.tsx
+++ b/src/entities/concert/ui/ConcertInfoTab.tsx
@@ -9,6 +9,7 @@ import {
 import { getMd, Md } from "../api/getMd";
 import ArtistTabPanel from "./ArtistTabPanel";
 import ConcertTabPanel from "./ConcertTabPanel";
+import SetlistTabPanel from "./SetlistTabPanel";
 import EmptyConcertInfoTabPanel from "./EmptyConcertInfoTabPanel";
 import {
   Tabs,
@@ -17,6 +18,7 @@ import {
   Tab,
   TabPanel,
 } from "@material-tailwind/react";
+import { getSetlistInfo, Setlist } from "../api/getSetlistInfo";
 
 interface ConcertInfoTabProps {
   concertId: number;
@@ -33,6 +35,7 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
     ConcertRequired[] | null
   >(null);
   const [mds, setMd] = useState<Md[] | null>(null);
+  const [setlist, setSetlist] = useState<Setlist[] | null>(null);
 
   useEffect(() => {
     if (!concertId || isNaN(concertId)) {
@@ -103,6 +106,20 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
     };
 
     fetchMds();
+  }, [concertId]);
+
+  useEffect(() => {
+    const fetchSetlist = async () => {
+      try {
+        const data = await getSetlistInfo(concertId);
+        setSetlist(data);
+      } catch (error) {
+        console.error("특정 콘서트의 셋리스트 목록 조회 API 호출 실패:", error);
+        setSetlist([]);
+      }
+    };
+
+    fetchSetlist();
   }, [concertId]);
 
   return (
@@ -200,7 +217,9 @@ function ConcertInfoTab({ concertId, ticketUrl }: ConcertInfoTabProps) {
             />
           )}
         </TabPanel>
-        <TabPanel value="setlist">셋리스트 내용</TabPanel>
+        <TabPanel value="setlist" className="p-0">
+          <SetlistTabPanel setlist={setlist} />
+        </TabPanel>
       </TabsBody>
     </Tabs>
   );

--- a/src/entities/concert/ui/ScheduleInfo.tsx
+++ b/src/entities/concert/ui/ScheduleInfo.tsx
@@ -23,7 +23,14 @@ function ScheduleInfo({ schedules }: ScheduleInfoProps) {
   const sortedSchedules = [...upcomingSchedules, ...pastSchedules];
 
   return (
-    <div className="pt-20 pl-16 pr-16">
+    <div className="pl-16 pr-16">
+      <div className="pt-24 pb-20">
+        <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+          다가온 콘서트 일정을
+          <br />
+          확인해 보세요
+        </p>
+      </div>
       <div className="flex flex-col gap-12">
         {sortedSchedules.map((schedule) => {
           const isPast = dayjs(schedule.scheduledAt).isBefore(dayjs(), "day");

--- a/src/entities/concert/ui/SetlistTabPanel.tsx
+++ b/src/entities/concert/ui/SetlistTabPanel.tsx
@@ -1,0 +1,59 @@
+import { useNavigate } from "react-router-dom";
+import { Setlist } from "../api/getSetlistInfo";
+import SetListCard from "../../../entities/setlist/ui/SetListCard";
+import formatDate from "../../../features/setlist/utils/formatDate";
+
+interface SetlistTabPanelProps {
+  setlist: Setlist[] | null;
+}
+
+function SetlistTabPanel({ setlist }: SetlistTabPanelProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="mx-16 pb-54">
+      <div className="pt-24 pb-20">
+        <p className="text-grayScaleWhite text-body-lg font-semibold font-NotoSansKR">
+          콘서트 셋리스트로
+          <br />
+          콘서트를 즐겨요
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-x-10 gap-y-24">
+        {setlist &&
+          setlist.map((setlistItem) => (
+            <div className="cursor-pointer">
+              <div className="w-full aspect-[108/158] relative">
+                {setlistItem.imgUrl ? (
+                  <img
+                    src={setlistItem.imgUrl}
+                    alt="이미지"
+                    className="w-full h-full rounded-6 object-cover"
+                  />
+                ) : (
+                  <div className="w-full bg-grayScaleBlack80 rounded-6" />
+                )}
+                {setlistItem.status && (
+                  <div className="absolute top-10 left-10 inline-flex items-center justify-center h-30 bg-grayScaleBlack90 rounded-24 px-13 ">
+                    <p className="text-grayScaleBlack30 text-caption-lg font-semibold font-NotoSansKR">
+                      {setlistItem.status}
+                    </p>
+                  </div>
+                )}
+
+                <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR mt-8 line-clamp-2">
+                  {setlistItem.title}
+                </p>
+                <p className="text-grayScaleBlack30 text-caption-lg font-semibold font-NotoSansKR mt-10 line-clamp-1">
+                  {formatDate(setlistItem.startDate)}
+                </p>
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export default SetlistTabPanel;

--- a/src/shared/ui/DetailInfo.tsx
+++ b/src/shared/ui/DetailInfo.tsx
@@ -37,7 +37,7 @@ function DetailInfo({
           className="w-full h-full object-cover"
         />
       )}
-      <div className="absolute bottom-24 left-19 pr-19">
+      <div className="absolute bottom-24 left-18 w-full pr-36">
         <p className="text-grayScaleWhite text-body-md font-medium font-NotoSansKR">
           {artist}
         </p>
@@ -45,7 +45,7 @@ function DetailInfo({
           {title}
         </p>
 
-        <div className="pt-18 w-324 border-b border-dashed border-grayScaleBlack50" />
+        <div className="pt-18 w-full border-b border-dashed border-grayScaleBlack50" />
 
         <p className="pt-18 text-grayScaleBlack30 text-body-lgs font-regular font-NotoSansKR">
           {date}
@@ -56,7 +56,7 @@ function DetailInfo({
         <a
           href={ticketSite ? ticketUrl : "#"}
           target="_blank"
-          className={`w-327 h-37 mt-16 pl-8 pr-8 flex items-center justify-between text-grayScaleBlack100 text-body-sm font-semibold font-NotoSansKR rounded-6 border-none cursor-pointer ${
+          className={`w-full h-37 mt-16 pl-8 pr-8 flex items-center justify-between text-grayScaleBlack100 text-body-sm font-semibold font-NotoSansKR rounded-6 border-none cursor-pointer ${
             ticketSite ? "bg-mainYellow30" : "bg-grayScaleBlack50"
           }`}
         >


### PR DESCRIPTION
### 📌 이슈 번호

- Closes #90

### 📌 PR 유형

- [x] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

### 📌 PR 내용

1. 셋리스트 정보 탭 UI
2. 특정 콘서트의 셋리스트 목록 조회 api 연결
3. 셋리스트 정보 탭 엠티뷰
4. 콘서트 상세 및 일정 정보 UI 수정
