### PR TITLE
[Feat/#144] 셋리스트 상세 화면 UI 구현

### DIFF
--- a/src/entities/concert/ui/SetlistTabPanel.tsx
+++ b/src/entities/concert/ui/SetlistTabPanel.tsx
@@ -37,7 +37,9 @@ function SetlistTabPanel({ setlist, concertId }: SetlistTabPanelProps) {
             <div
               className="cursor-pointer"
               onClick={() => {
-                navigate(`/setlist/${setlistItem.id}/${concertId}`);
+                navigate(`/setlist/${setlistItem.id}/${concertId}`, {
+                  state: { setlistTitle: setlistItem.title },
+                });
               }}
             >
               <div className="w-full aspect-[108/158] relative">

--- a/src/entities/setlist/ui/SetListCard.tsx
+++ b/src/entities/setlist/ui/SetListCard.tsx
@@ -25,7 +25,9 @@ function SetListCard({
     <div
       className="basis-0 flex-grow min-w-[108px] max-w-[132px] cursor-pointer"
       onClick={() => {
-        navigate(`/setlist/${setlistId}/${concertId}`);
+        navigate(`/setlist/${setlistId}/${concertId}`, {
+          state: { setlistTitle: title },
+        });
       }}
     >
       <div className="aspect-[108/158] relative">

--- a/src/entities/setlist/ui/SetlistSongList.tsx
+++ b/src/entities/setlist/ui/SetlistSongList.tsx
@@ -14,6 +14,9 @@ type SetlistSongListProps = {
 function SetlistSongList({ setlistId, setlistType }: SetlistSongListProps) {
   const setSetlistId = useSetRecoilState(setlistIdState);
   const navigate = useNavigate();
+  const handleClick = () => {
+    window.location.href = "https://forms.gle/aMj5C4LhDcMzueWz5";
+  };
   const { data: songs, isLoading, isError } = useSetlistSongList({ setlistId });
 
   if (isLoading) {
@@ -25,9 +28,19 @@ function SetlistSongList({ setlistId, setlistType }: SetlistSongListProps) {
 
   return (
     <div className="mx-16 mt-30 pb-30">
-      <p className="text-grayScaleWhite text-Body1-sm font-semibold font-NotoSansKR">
-        {setlistType === SetlistType.EXPECTED ? "예상" : ""} 셋리스트
-      </p>
+      <div className="flex flex-row justify-between items-end">
+        <p className="text-grayScaleWhite text-Body1-sm font-semibold font-NotoSansKR">
+          {setlistType === SetlistType.EXPECTED ? "예상" : ""} 셋리스트
+        </p>
+        <div
+          onClick={handleClick}
+          className="bg-grayScaleBlack100 rounded-24 border border-solid border-grayScaleBlack80 cursor-pointer"
+        >
+          <p className="px-13 py-4 text-grayScaleBlack50 text-Caption1-Bold font-bold font-NotoSansKR">
+            정보 제보
+          </p>
+        </div>
+      </div>
       {songs?.length === 0 ? (
         <EmptySongList />
       ) : (

--- a/src/entities/setlist/ui/SetlistSongList.tsx
+++ b/src/entities/setlist/ui/SetlistSongList.tsx
@@ -26,7 +26,7 @@ function SetlistSongList({ setlistId, setlistType }: SetlistSongListProps) {
   return (
     <div className="mx-16 mt-30 pb-30">
       <p className="text-grayScaleWhite text-Body1-sm font-semibold font-NotoSansKR">
-        {setlistType === SetlistType.EXPECTED ? "예상" : "대표"} 셋리스트 목록
+        {setlistType === SetlistType.EXPECTED ? "예상" : ""} 셋리스트
       </p>
       {songs?.length === 0 ? (
         <EmptySongList />

--- a/src/features/setlist/ui/BriefSetlistSongList.tsx
+++ b/src/features/setlist/ui/BriefSetlistSongList.tsx
@@ -8,11 +8,13 @@ import { useNavigate } from "react-router-dom";
 type BriefSetlistSongListProps = {
   setlistId: number;
   concertId: number;
+  setlistTitle: string;
 };
 
 function BriefSetlistSongList({
   setlistId,
   concertId,
+  setlistTitle,
 }: BriefSetlistSongListProps) {
   const { data: songs, isLoading, isError } = useSetlistSongList({ setlistId });
 
@@ -46,7 +48,9 @@ function BriefSetlistSongList({
       {/* <img src={MoreIcon} alt="More Icon" /> */}
       <div
         onClick={() => {
-          navigate(`/setlist/${setlistId}/${concertId}`);
+          navigate(`/setlist/${setlistId}/${concertId}`, {
+            state: { setlistTitle },
+          });
         }}
         className="h-57 w-full flex flex-col justify-center bg-grayScaleBlack80 rounded-b-10 cursor-pointer"
       >

--- a/src/features/setlist/ui/InterestConcertSetlist.tsx
+++ b/src/features/setlist/ui/InterestConcertSetlist.tsx
@@ -44,6 +44,7 @@ function InterestConcertSetlist() {
       <BriefSetlistSongList
         setlistId={setlist.id}
         concertId={Number(concertId)}
+        setlistTitle={setlist.title}
       />
     </div>
   );

--- a/src/features/setlist/ui/InterestConcertSetlist.tsx
+++ b/src/features/setlist/ui/InterestConcertSetlist.tsx
@@ -12,7 +12,6 @@ function InterestConcertSetlist() {
     isLoading,
     isError,
   } = useInterestConcertSetlist({ concertId: Number(concertId) });
-
   if (isLoading) {
     return <div>Loading...</div>;
   }
@@ -23,8 +22,8 @@ function InterestConcertSetlist() {
   let label1 = "";
   let label2 = "";
 
-  if (!setlist || !setlist!.id) {
-    return null;
+  if (!setlist || setlist!.id === undefined) {
+    return <EmptySetList />;
   } else if (setlist.type === SetlistType.EXPECTED) {
     label1 = "이전 콘서트를 기반으로";
     label2 = "이런 노래를 예상해요";
@@ -35,23 +34,17 @@ function InterestConcertSetlist() {
 
   return (
     <div className="mx-16 pb-38">
-      {!setlist || !setlist!.id ? (
-        <EmptySetList />
-      ) : (
-        <>
-          <div className="text-grayScaleWhite text-Body1-sm font-semibold font-NotoSansKR mt-24">
-            <p>{label1}</p>
-            <p>{label2}</p>
-          </div>
-          {setlist.type !== SetlistType.EXPECTED ? (
-            <InterestConcertSetlistDetail setlist={setlist} />
-          ) : null}
-          <BriefSetlistSongList
-            setlistId={setlist.id}
-            concertId={Number(concertId)}
-          />
-        </>
-      )}
+      <div className="text-grayScaleWhite text-Body1-sm font-semibold font-NotoSansKR mt-24">
+        <p>{label1}</p>
+        <p>{label2}</p>
+      </div>
+      {setlist.type !== SetlistType.EXPECTED ? (
+        <InterestConcertSetlistDetail setlist={setlist} />
+      ) : null}
+      <BriefSetlistSongList
+        setlistId={setlist.id}
+        concertId={Number(concertId)}
+      />
     </div>
   );
 }

--- a/src/pages/SetlistDetailPage.tsx
+++ b/src/pages/SetlistDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import SetlistDetail from "../entities/setlist/ui/SetlistDetail";
 import ListHeader from "../shared/ui/ListHeader";
 import SetlistSongList from "../entities/setlist/ui/SetlistSongList";
@@ -6,6 +6,8 @@ import { useEffect, useState } from "react";
 
 function SetlistDetailPage() {
   const { setlistId, concertId } = useParams();
+  const location = useLocation();
+  const setlistTitle = location.state.setlistTitle;
   const [setlistType, setSetlistType] = useState<string | null>(null);
   // 페이지 진입 시 스크롤 맨 위로 이동
   useEffect(() => {
@@ -14,7 +16,7 @@ function SetlistDetailPage() {
 
   return (
     <div>
-      <ListHeader />
+      <ListHeader title={setlistTitle} />
       <SetlistDetail
         concertId={Number(concertId)}
         setlistId={Number(setlistId)}

--- a/src/widgets/ChangeConcertConfirmModal.tsx
+++ b/src/widgets/ChangeConcertConfirmModal.tsx
@@ -24,7 +24,10 @@ function ChangeConcertConfirmModal({
           animationData={InterestConcertToastIconMotion}
           loop={false}
           autoplay={true}
-          style={{ width: 24, height: 24 }}
+          renderer="svg"
+          rendererSettings={{
+            preserveAspectRatio: "xMidYMid meet",
+          }}
         />
         <span>관심 공연을 변경했어요</span>
       </div>,

--- a/src/widgets/DeleteConfirmModal.tsx
+++ b/src/widgets/DeleteConfirmModal.tsx
@@ -13,7 +13,14 @@ function DeleteConfirmModal({ isOpen, onClose }: DeleteConfirmModalProps) {
     localStorage.removeItem(STORAGE_KEY);
     toast(
       <div className="flex items-center space-x-13 text-grayScaleWhite text-Body4-sm font-semibold font-NotoSansKR">
-        <Lottie animationData={DeleteConcertToastIconMotion} loop={false} />
+        <Lottie
+          animationData={DeleteConcertToastIconMotion}
+          loop={false}
+          renderer="svg"
+          rendererSettings={{
+            preserveAspectRatio: "xMidYMid meet",
+          }}
+        />
         <span>관심 콘서트가 삭제되었어요</span>
       </div>,
       {


### PR DESCRIPTION
<!-- 제목은 [Feat/#이슈 번호] "pr message" -->

### 📌 이슈 번호

- Closes #144

### 📌 PR 유형

- [x] 새 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

### 📌 PR 내용

1. 셋리스트 네이밍 변경
2. 셋리스트 상세 페이지에 정보 제보 기능 추가
3. 셋리스트 상세 페이지 헤더에 셋리스트 제목 추가
4. 토스트바 사파리 UI 수정

### 📸 스크린샷 (선택)

### 🔗 참고 자료 (선택)
