### PR TITLE
[Fix/#380] 인스타그램 이미지 깨지는 문제 해결

### DIFF
--- a/src/entities/concert/ui/DetailInfo.tsx
+++ b/src/entities/concert/ui/DetailInfo.tsx
@@ -4,6 +4,7 @@ import ConcertVenueIcon from "../../../shared/assets/ConcertVenueIcon.svg";
 import HotConcertChipIcon from "../../../shared/assets/HotConcertChipIcon.svg";
 import AlarmIcon from "../../../shared/assets/AlarmIcon.svg";
 import AlarmFillIcon from "../../../shared/assets/AlarmFillIcon.svg";
+import { getImageSrc } from "../../../shared/utils/getImageSrc";
 import { useState } from "react";
 import { ConcertStatus } from "../types";
 import { useRecoilState } from "recoil";
@@ -139,7 +140,7 @@ function DetailInfo({
       <div className="h-337 absolute inset-0 bg-grayScaleBlack100 opacity-70"></div>
       {imageUrl ? (
         <img
-          src={imageUrl}
+          src={getImageSrc(imageUrl)}
           className="w-full h-full object-cover"
           onError={(e) => {
             e.currentTarget.src = EmptyConcertImageIcon;

--- a/src/entities/concert/ui/MdCard.tsx
+++ b/src/entities/concert/ui/MdCard.tsx
@@ -22,6 +22,9 @@ function MdCard({ name, price, imgUrl, ticketUrl }: MdCardProps) {
           <img
             src={getImageSrc(imgUrl)}
             className="w-full h-full rounded-6 object-cover"
+            onError={(e) => {
+              e.currentTarget.src = EmptyConcertCardIcon;
+            }}
           />
         ) : (
           <img

--- a/src/entities/concert/ui/MdSlideCard.tsx
+++ b/src/entities/concert/ui/MdSlideCard.tsx
@@ -15,6 +15,9 @@ function MdSlideCard({ name, price, imageUrl }: MdSlideCardProps) {
           <img
             src={getImageSrc(imageUrl)}
             className="w-full h-full rounded-6 object-cover"
+            onError={(e) => {
+              e.currentTarget.src = EmptyConcertCardIcon;
+            }}
           />
         ) : (
           <img

--- a/src/entities/concert/ui/SectionConcertSlideCard.tsx
+++ b/src/entities/concert/ui/SectionConcertSlideCard.tsx
@@ -30,6 +30,9 @@ function SectionConcertSlideCard({
           <img
             src={getImageSrc(imageUrl)}
             className="w-full h-full rounded-6 object-cover"
+            onError={(e) => {
+              e.currentTarget.src = EmptyConcertCardIcon;
+            }}
           />
         ) : (
           <img

--- a/src/features/interest/ui/InterestConcertCarouselSlide.tsx
+++ b/src/features/interest/ui/InterestConcertCarouselSlide.tsx
@@ -54,6 +54,9 @@ function InterestConcertCarouselSlide({
             <img
               src={poster ? getImageSrc(poster) : ConcertPosterEmptyIcon}
               className="w-84 h-112 rounded-4 object-cover flex-shrink-0"
+              onError={(e) => {
+                e.currentTarget.src = ConcertPosterEmptyIcon;
+              }}
             />
             <div>
               <div className="inline-flex items-center justify-center px-10 py-4 rounded-24 bg-mainYellow30">

--- a/src/features/interest/ui/SelectableInfiniteConcertList.tsx
+++ b/src/features/interest/ui/SelectableInfiniteConcertList.tsx
@@ -1,15 +1,17 @@
 import { motion } from "framer-motion";
 import { useInView } from "react-intersection-observer";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { Concert } from "../../../entities/concert/types";
-import type { SelectedConcert } from "../../../pages/SetInterestConcertPage";
-import EmptyConcertCard from "../../../shared/assets/EmptyConcertCardIcon.svg";
 import { StateWithSetter } from "../../../shared/types/props";
 import ChipState from "../../../shared/ui/ChipState/ChipState";
+import EmptyConcertCard from "../../../shared/assets/EmptyConcertCardIcon.svg";
 import {
   getConcertDisplayDate,
   getConcertDisplayStatus,
   getConcertDisplayTitle,
 } from "../../../shared/utils/concertDisplay";
+import type { SelectedConcert } from "../../../pages/SetInterestConcertPage";
 import { getImageSrc } from "../../../shared/utils/getImageSrc";
 
 type SelectableInfiniteConcertListProps = {
@@ -34,6 +36,27 @@ export function SelectableInfiniteConcertList({
     setValue: setSelectedConcerts,
   },
 }: SelectableInfiniteConcertListProps) {
+  const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
+  const [loadingImages, setLoadingImages] = useState<Set<string>>(
+    new Set(concerts?.map((c) => c.id) ?? []),
+  );
+
+  const handleImageError = (concertId: string) => {
+    setFailedImages((prev) => new Set(prev).add(concertId));
+    setLoadingImages((prev) => {
+      const next = new Set(prev);
+      next.delete(concertId);
+      return next;
+    });
+  };
+
+  const handleImageLoad = (concertId: string) => {
+    setLoadingImages((prev) => {
+      const next = new Set(prev);
+      next.delete(concertId);
+      return next;
+    });
+  };
   const { ref } = useInView({
     triggerOnce: false,
     onChange: (inView) => {
@@ -73,15 +96,26 @@ export function SelectableInfiniteConcertList({
           >
             <div className="cursor-pointer">
               <div className="w-full aspect-[108/158] relative">
-                {concert.poster ? (
-                  <img
-                    src={getImageSrc(concert.poster)}
-                    className={`w-full h-full rounded-6 object-cover ${
-                      isSelected
-                        ? "border-2 border-mainYellow30"
-                        : "border-2 border-transparent"
-                    }`}
-                  />
+                {concert.poster && !failedImages.has(concert.id) ? (
+                  <>
+                    {loadingImages.has(concert.id) && (
+                      <div className="absolute inset-0 bg-grayScaleBlack80 rounded-6 animate-pulse" />
+                    )}
+                    <img
+                      src={getImageSrc(concert.poster)}
+                      onLoad={() => handleImageLoad(concert.id)}
+                      onError={() => handleImageError(concert.id)}
+                      className={`w-full h-full rounded-6 object-cover transition-opacity duration-300 ${
+                        loadingImages.has(concert.id)
+                          ? "opacity-0"
+                          : "opacity-100"
+                      } ${
+                        isSelected
+                          ? "border-2 border-mainYellow30"
+                          : "border-2 border-transparent"
+                      }`}
+                    />
+                  </>
                 ) : (
                   <img
                     src={EmptyConcertCard}


### PR DESCRIPTION
<!-- 제목은 [Feat/#이슈 번호] "pr message" -->

### 📌 이슈 번호

- Closes #380 

### 📌 PR 유형

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

### 📌 PR 내용

1. 이미지 에러 뜰 때 엠티뷰 띄우기
2. 콘서트 상세 페이지에서도 인스타그램 이미지 프록시로 조회하도록 수정
